### PR TITLE
feature: expose close and exit event

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,23 +51,19 @@ var Tunnel = inherit(EventEmitter, {
 
         this._tunnel = childProcess.spawn('ssh', this._buildSSHArgs());
 
+        var cleanup = function () {
+            _this._tunnel.stderr.removeAllListeners('data');
+        };
+
         this._tunnel.stderr.on('data', function (data) {
             if (/success/.test(data)) {
+                cleanup();
                 return _this._resolveTunnel();
             }
 
             if (/failed/.test(data)) {
-                if (_this._tunnelDeferred.promise.isFulfilled()) {
-                    return;
-                }
+                cleanup();
                 return _this._rejectTunnel();
-            }
-
-            if (/killed/i.test(data)) {
-                var msg = data.toString().toLowerCase();
-                var killMsg = msg.slice(msg.indexOf('killed')).trim();
-
-                console.info('INFO: Tunnel is ' + killMsg);
             }
         });
 

--- a/test/index.js
+++ b/test/index.js
@@ -161,26 +161,6 @@ describe('Tunnel', function () {
                         .to.be.not.calledWith(util.format('ERROR: failed to create tunnel to %s.', tunnel.proxyHost));
                 });
 
-                it('should log a kill signal with which the tunnel is closed', function () {
-                    tunnel = createTunnel();
-
-                    tunnel.open();
-                    ssh.stderr.emit('data', 'channel 0: \nKilled BY signal 2');
-
-                    expect(console.info.secondCall.args[0])
-                        .to.be.equal('INFO: Tunnel is killed by signal 2');
-                });
-
-                it('should not log a kill signal if tunnel is closed successfully', function () {
-                    tunnel = createTunnel();
-
-                    tunnel.open();
-                    ssh.stderr.emit('data', 'Exit status 0');
-
-                    expect(console.info).to.be.calledOnce;
-                    expect(console.info.firstCall.args[0]).to.not.match(/INFO: Tunnel is killed/);
-                });
-
                 it('should reject tunnel opening if error occured', function () {
                     tunnel = createTunnel();
 
@@ -252,9 +232,9 @@ describe('Tunnel', function () {
 
                 var closeHandler = sandbox.stub();
                 tunnel.on('close', closeHandler);
-                ssh.emit('close', 15, 'SIGTERM');
+                ssh.emit('close', null, 'SIGKILL');
 
-                return expect(closeHandler).to.be.calledWith(15, 'SIGTERM');
+                return expect(closeHandler).to.be.calledWith(null, 'SIGKILL');
             });
 
             it('should emit exit event', function () {
@@ -263,9 +243,9 @@ describe('Tunnel', function () {
 
                 var exitHandler = sandbox.stub();
                 tunnel.on('exit', exitHandler);
-                ssh.emit('exit', 15, 'SIGTERM');
+                ssh.emit('exit', 0, null);
 
-                return expect(exitHandler).to.be.calledWith(15, 'SIGTERM');
+                return expect(exitHandler).to.be.calledWith(0, null);
             });
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -245,6 +245,28 @@ describe('Tunnel', function () {
                     clock.restore();
                 });
             });
+
+            it('should emit close event', function () {
+                tunnel = createTunnel();
+                tunnel.open();
+
+                var closeHandler = sandbox.stub();
+                tunnel.on('close', closeHandler);
+                ssh.emit('close', 15, 'SIGTERM');
+
+                return expect(closeHandler).to.be.calledWith(15, 'SIGTERM');
+            });
+
+            it('should emit exit event', function () {
+                tunnel = createTunnel();
+                tunnel.open();
+
+                var exitHandler = sandbox.stub();
+                tunnel.on('exit', exitHandler);
+                ssh.emit('exit', 15, 'SIGTERM');
+
+                return expect(exitHandler).to.be.calledWith(15, 'SIGTERM');
+            });
         });
     });
 


### PR DESCRIPTION
- Exposed `close` and `exit` events.
- Get rid of kill (not actually `SIGKILL`) detection based on the stderr parsing – parent process should wait for `exit` event instead. 
