### PR TITLE
fix: add ssh-rsa options separately

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,14 +170,14 @@ var Tunnel = inherit(EventEmitter, {
             // heartbeat messages existence is logged to debug3 (penSSH_7.9p1, LibreSSL 2.7.3, macOC Catalina)
             this._shouldBeVerbose() ? '-vvv' : '-v',
             this._strictHostKeyChecking === false ? '-o StrictHostKeyChecking=no' : '',
-            this._enableDeprecatedSshRsa && '-o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa',
+            this._enableDeprecatedSshRsa && ['-o HostKeyAlgorithms=+ssh-rsa', '-o PubkeyAcceptedKeyTypes=+ssh-rsa'],
             this._compression !== undefined ?
                 util.format('-o Compression=%s', this._compression ? 'yes' : 'no')
                 : '',
             this._identity ? util.format('-i %s', this._identity) : '',
             util.format('-p %d', this._sshPort),
             (this.user ? this.user + '@' : '') + this.host
-        ].filter(Boolean);
+        ].filter(Boolean).flat();
     },
 
     _shouldBeVerbose: function () {

--- a/test/index.js
+++ b/test/index.js
@@ -203,7 +203,8 @@ describe('Tunnel', function () {
 
                     var sshArgs = childProcess.spawn.lastCall.args[1];
 
-                    expect(sshArgs).to.contain('-o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa');
+                    expect(sshArgs).to.contain('-o HostKeyAlgorithms=+ssh-rsa');
+                    expect(sshArgs).to.contain('-o PubkeyAcceptedKeyTypes=+ssh-rsa');
                 });
 
                 it('should reject tunnel opening if failed to create tunnel', function () {


### PR DESCRIPTION
If the common string `'-o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa'` is used, SSH will parse it as a single `HostKeyAlgorithms` option with incorrect parameters. Therefore, it's necessary to pass these options separately.